### PR TITLE
chore: prepare lanting backend for EC2 runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.env
+.env.*
+!.env.example
+!.env.bio.example
+node_modules
+dist
+coverage
+test
+*.log
+.DS_Store
+README.md

--- a/.env.bio.example
+++ b/.env.bio.example
@@ -64,6 +64,7 @@ FRONTEND_URL="http://localhost:3000"
 
 #===============================================================================
 # Email IMAP
+EMAIL_WORKER_ENABLED=false
 #===============================================================================
 EMAIL_HOST=imap.example.com
 EMAIL_PORT=993

--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,7 @@ FRONTEND_URL="http://localhost:3000"
 
 #===============================================================================
 # Email IMAP
+EMAIL_WORKER_ENABLED=false
 #===============================================================================
 EMAIL_HOST=imap.example.com
 EMAIL_PORT=993

--- a/.github/workflows/node-deploy-bio-staging.yml
+++ b/.github/workflows/node-deploy-bio-staging.yml
@@ -1,7 +1,4 @@
-# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
-# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
-
-name: bio staging deployment
+name: Validate dev-bio
 
 on:
   push:
@@ -11,44 +8,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
     steps:
       - uses: actions/checkout@v4
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-southeast-1
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Build, tag, and push image to Amazon ECR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: lanting-backend
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      - name: deploy to cluster
-        uses: kodermax/kubectl-aws-eks@main
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: lanting-backend
-          ECR_CONTAINER_NAME: lanting-backend-bio-staging
-          IMAGE_TAG: ${{ github.sha }}
-        with:
-          args: set image --namespace="lanting" deployment/$ECR_CONTAINER_NAME $ECR_CONTAINER_NAME=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      - name: verify deployment
-        uses: kodermax/kubectl-aws-eks@main
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
-          ECR_CONTAINER_NAME: lanting-backend-bio-staging
-        with:
-          args: rollout status deployment/$ECR_CONTAINER_NAME --namespace="lanting"
+      - run: docker build --platform linux/amd64 .

--- a/.github/workflows/node-deploy-bio.yml
+++ b/.github/workflows/node-deploy-bio.yml
@@ -1,7 +1,4 @@
-# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
-# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
-
-name: bio deployment
+name: Deploy lanting-backend-bio
 
 on:
   push:
@@ -9,46 +6,15 @@ on:
       - bio
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  deploy:
     permissions:
       contents: read
-      packages: write
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-southeast-1
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Build, tag, and push image to Amazon ECR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: lanting-backend
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      - name: deploy to cluster
-        uses: kodermax/kubectl-aws-eks@main
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: lanting-backend
-          ECR_CONTAINER_NAME: lanting-backend-bio
-          IMAGE_TAG: ${{ github.sha }}
-        with:
-          args: set image --namespace="lanting" deployment/$ECR_CONTAINER_NAME $ECR_CONTAINER_NAME=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      - name: verify deployment
-        uses: kodermax/kubectl-aws-eks@main
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
-          ECR_CONTAINER_NAME: lanting-backend-bio
-        with:
-          args: rollout status deployment/$ECR_CONTAINER_NAME --namespace="lanting"
+      id-token: write
+    uses: id-life/aws-runtime/.github/workflows/deploy-service.yml@main
+    with:
+      service: lanting-backend-bio
+      ecr_repository: lanting-backend
+      docker_context: .
+      dockerfile: Dockerfile
+      release_id: ${{ github.sha }}
+      aws_role_arn: ${{ vars.AWS_DEPLOY_ROLE_ARN }}

--- a/.github/workflows/node-deploy-main.yml
+++ b/.github/workflows/node-deploy-main.yml
@@ -1,7 +1,4 @@
-# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
-# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
-
-name: main deployment
+name: Deploy lanting-backend
 
 on:
   push:
@@ -9,44 +6,15 @@ on:
       - main
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  deploy:
     permissions:
       contents: read
-      packages: write
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-southeast-1
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Build, tag, and push image to Amazon ECR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: lanting-backend
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      - name: deploy to cluster
-        uses: kodermax/kubectl-aws-eks@main
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: lanting-backend
-          IMAGE_TAG: ${{ github.sha }}
-        with:
-          args: set image --namespace="lanting" deployment/$ECR_REPOSITORY $ECR_REPOSITORY=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      - name: verify deployment
-        uses: kodermax/kubectl-aws-eks@main
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
-        with:
-          args: rollout status deployment/lanting-backend --namespace="lanting"
+      id-token: write
+    uses: id-life/aws-runtime/.github/workflows/deploy-service.yml@main
+    with:
+      service: lanting-backend
+      ecr_repository: lanting-backend
+      docker_context: .
+      dockerfile: Dockerfile
+      release_id: ${{ github.sha }}
+      aws_role_arn: ${{ vars.AWS_DEPLOY_ROLE_ARN }}

--- a/.github/workflows/node-deploy-staging.yml
+++ b/.github/workflows/node-deploy-staging.yml
@@ -1,7 +1,4 @@
-# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
-# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
-#
-name: staging deployment
+name: Validate dev
 
 on:
   push:
@@ -11,44 +8,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
     steps:
       - uses: actions/checkout@v4
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-southeast-1
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Build, tag, and push image to Amazon ECR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: lanting-backend
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      - name: deploy to cluster
-        uses: kodermax/kubectl-aws-eks@main
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: lanting-backend
-          ECR_CONTAINER_NAME: lanting-backend-staging
-          IMAGE_TAG: ${{ github.sha }}
-        with:
-          args: set image --namespace="lanting" deployment/$ECR_CONTAINER_NAME $ECR_CONTAINER_NAME=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      - name: verify deployment
-        uses: kodermax/kubectl-aws-eks@main
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
-          ECR_CONTAINER_NAME: lanting-backend-staging
-        with:
-          args: rollout status deployment/$ECR_CONTAINER_NAME --namespace="lanting"
+      - run: docker build --platform linux/amd64 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,51 @@
-FROM node:22-slim AS builder
+# syntax=docker/dockerfile:1.7
+
+FROM node:22-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS builder
 
 WORKDIR /app
+RUN apt-get -o Acquire::Retries=5 update \
+    && apt-get -o Acquire::Retries=5 install -y --no-install-recommends openssl \
+    && rm -rf /var/lib/apt/lists/*
+RUN corepack enable
 
-COPY package*.json pnpm-*.yaml ./
-COPY prisma ./prisma/
-
-RUN corepack enable && \
-    npm install @antfu/ni -g
-RUN nci
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY prisma ./prisma
+RUN --mount=type=cache,id=lanting-backend-pnpm,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
 
 COPY . .
+RUN --mount=type=cache,id=lanting-backend-prisma,target=/root/.cache/prisma \
+    pnpm prisma:generate
+RUN pnpm test:migration \
+    && pnpm build \
+    && pnpm prune --prod --ignore-scripts
 
-RUN npm run build
+FROM node:22-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS runtime
 
-FROM node:22-slim
+COPY --from=builder /app/package.json /tmp/lanting-build-complete
+RUN apt-get -o Acquire::Retries=5 update \
+    && apt-get -o Acquire::Retries=5 install -y --no-install-recommends ca-certificates openssl wget \
+    && wget --tries=10 --retry-connrefused --timeout=30 \
+      https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+      -O /tmp/google-chrome.deb \
+    && apt-get -o Acquire::Retries=5 install -y --no-install-recommends /tmp/google-chrome.deb \
+    && rm -rf /var/lib/apt/lists/* /tmp/google-chrome.deb /tmp/lanting-build-complete
 
-RUN apt-get update && apt-get install -y \
-    openssl \
-    wget \
-    ca-certificates \
-    && wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-    && dpkg -i google-chrome-stable_current_amd64.deb || true \
-    && apt-get install -f -y \
-    && rm google-chrome-stable_current_amd64.deb \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV CHROME_BIN=/usr/bin/google-chrome
+ENV NODE_ENV=production \
+    PORT=8000 \
+    CHROME_BIN=/usr/bin/google-chrome \
+    EMAIL_WORKER_ENABLED=false
 
 WORKDIR /app
+COPY --from=builder --chown=node:node /app/node_modules ./node_modules
+COPY --from=builder --chown=node:node /app/package.json ./package.json
+COPY --from=builder --chown=node:node /app/dist ./dist
+COPY --from=builder --chown=node:node /app/prisma ./prisma
+RUN install -d -o node -g node -m 0750 /app/data /tmp/lanting-chromium
 
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/package*.json ./
-COPY --from=builder /app/pnpm-*.yaml ./
-COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/prisma ./prisma
+USER node
+EXPOSE 8000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD ["node", "-e", "fetch('http://127.0.0.1:8000/healthz').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
 
-EXPOSE 3000
-CMD [ "npm", "run", "start:prod" ]
+CMD ["node", "dist/main"]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "prisma migrate deploy && node dist/main",
+    "start:prod": "node dist/main",
+    "test:migration": "jest --runInBand --detectOpenHandles app.controller.spec.ts health/health.controller.spec.ts common/imapflow/imapflow.migration.spec.ts",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
@@ -114,6 +115,9 @@
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/$1"
     },
     "collectCoverageFrom": [
       "**/*.(t|j)s"

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -15,8 +15,8 @@ describe("appController", () => {
   })
 
   describe("root", () => {
-    it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe("Hello World!")
+    it("returns the service welcome message", () => {
+      expect(appController.getHello()).toBe("Welcome to lanting-backend!")
     })
   })
 })

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { AuthModule } from "./auth/auth.module"
 import { CommonModule } from "./common/common.module"
 import { ConfigModule } from "./config/config.module"
 import { EmailModule } from "./email/email.module"
+import { HealthModule } from "./health/health.module"
 import { TributeModule } from "./tribute/tribute.module"
 
 @Module({
@@ -18,6 +19,7 @@ import { TributeModule } from "./tribute/tribute.module"
     CommonModule,
     EmailModule,
     AuthModule,
+    HealthModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/common/imapflow/imapflow.migration.spec.ts
+++ b/src/common/imapflow/imapflow.migration.spec.ts
@@ -1,0 +1,31 @@
+import { ImapflowService } from "./imapflow.service"
+
+describe("ImapflowService migration gate", () => {
+  function create(enabled: boolean) {
+    const config = { emailWorkerEnabled: enabled }
+    return new ImapflowService(config as any, {} as any, {} as any)
+  }
+
+  it("does not initialize email or scheduled work in web slots", async () => {
+    const service = create(false)
+    const initialize = jest
+      .spyOn(service as any, "initializeEmail")
+      .mockResolvedValue(undefined)
+
+    await service.onModuleInit()
+    await service.checkSpamEmails()
+
+    expect(initialize).not.toHaveBeenCalled()
+  })
+
+  it("initializes email only for the explicitly enabled worker", async () => {
+    const service = create(true)
+    const initialize = jest
+      .spyOn(service as any, "initializeEmail")
+      .mockResolvedValue(undefined)
+
+    await service.onModuleInit()
+
+    expect(initialize).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/common/imapflow/imapflow.service.ts
+++ b/src/common/imapflow/imapflow.service.ts
@@ -55,6 +55,10 @@ export class ImapflowService implements OnModuleInit, OnModuleDestroy {
   ) {}
 
   async onModuleInit() {
+    if (!this.configService.emailWorkerEnabled) {
+      this.logger.log("Email worker disabled")
+      return
+    }
     this.logger.log("ImapflowService initializing...")
     await this.initializeEmail()
   }
@@ -411,6 +415,9 @@ export class ImapflowService implements OnModuleInit, OnModuleDestroy {
    */
   @Cron(CronExpression.EVERY_5_MINUTES)
   async checkSpamEmails() {
+    if (!this.configService.emailWorkerEnabled) {
+      return
+    }
     if (!this.client) {
       return
     }

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -114,4 +114,10 @@ export class ConfigService {
   get emailPassword() {
     return this.nestConfigService.get("app.EMAIL_PASSWORD", { infer: true })
   }
+
+  get emailWorkerEnabled() {
+    return this.nestConfigService.get("app.EMAIL_WORKER_ENABLED", {
+      infer: true,
+    })
+  }
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -55,6 +55,10 @@ export const appConfigSchema = z.object({
   EMAIL_PORT: z.coerce.number().optional(),
   EMAIL_USERNAME: z.string().optional(),
   EMAIL_PASSWORD: z.string().optional(),
+  EMAIL_WORKER_ENABLED: z
+    .enum(["true", "false"])
+    .default("false")
+    .transform((value) => value === "true"),
 })
 
 export type AppConfig = z.infer<typeof appConfigSchema>

--- a/src/health/health.controller.spec.ts
+++ b/src/health/health.controller.spec.ts
@@ -1,0 +1,47 @@
+import { HealthController } from "./health.controller"
+
+describe("HealthController migration contract", () => {
+  const status = jest.fn()
+  const response = { status } as any
+  const prisma = { $queryRawUnsafe: jest.fn() }
+  const redisClient = { ping: jest.fn() }
+  const redis = { getClient: () => redisClient }
+  const controller = new HealthController(prisma as any, redis as any)
+
+  beforeEach(() => jest.clearAllMocks())
+
+  it("keeps liveness dependency-free", () => {
+    expect(controller.healthz()).toEqual({
+      ok: true,
+      service: "lanting-backend",
+    })
+    expect(prisma.$queryRawUnsafe).not.toHaveBeenCalled()
+    expect(redisClient.ping).not.toHaveBeenCalled()
+  })
+
+  it("uses read-only dependency checks for readiness", async () => {
+    prisma.$queryRawUnsafe.mockResolvedValue([{ 1: 1 }])
+    redisClient.ping.mockResolvedValue("PONG")
+
+    await expect(controller.readyz(response)).resolves.toEqual({
+      ok: true,
+      database: true,
+      redis: true,
+    })
+    expect(prisma.$queryRawUnsafe).toHaveBeenCalledWith("SELECT 1")
+    expect(redisClient.ping).toHaveBeenCalledTimes(1)
+    expect(status).not.toHaveBeenCalled()
+  })
+
+  it("fails closed without exposing dependency errors", async () => {
+    prisma.$queryRawUnsafe.mockRejectedValue(new Error("sensitive detail"))
+    redisClient.ping.mockResolvedValue("PONG")
+
+    await expect(controller.readyz(response)).resolves.toEqual({
+      ok: false,
+      database: false,
+      redis: false,
+    })
+    expect(status).toHaveBeenCalledWith(503)
+  })
+})

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get, Res } from "@nestjs/common"
+import type { Response } from "express"
+import { PrismaService } from "../common/prisma/prisma.service"
+import { RedisService } from "../common/redis/redis.service"
+
+const READY_TIMEOUT_MS = 2_000
+
+@Controller()
+export class HealthController {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly redis: RedisService,
+  ) {}
+
+  @Get("healthz")
+  healthz() {
+    return { ok: true, service: "lanting-backend" }
+  }
+
+  @Get("readyz")
+  async readyz(@Res({ passthrough: true }) response: Response) {
+    try {
+      await Promise.race([
+        Promise.all([
+          this.prisma.$queryRawUnsafe("SELECT 1"),
+          this.redis.getClient().ping(),
+        ]),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("readiness timeout")), READY_TIMEOUT_MS),
+        ),
+      ])
+      return { ok: true, database: true, redis: true }
+    } catch {
+      response.status(503)
+      return { ok: false, database: false, redis: false }
+    }
+  }
+}

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -1,0 +1,5 @@
+import { Module } from "@nestjs/common"
+import { HealthController } from "./health.controller"
+
+@Module({ controllers: [HealthController] })
+export class HealthModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Logger, ValidationPipe } from "@nestjs/common"
+import { Logger, RequestMethod, ValidationPipe } from "@nestjs/common"
 import { NestFactory } from "@nestjs/core"
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger"
 import { AppModule } from "./app.module"
@@ -19,7 +19,12 @@ async function bootstrap() {
   )
 
   if (configService.apiPrefix) {
-    app.setGlobalPrefix(configService.apiPrefix)
+    app.setGlobalPrefix(configService.apiPrefix, {
+      exclude: [
+        { path: "healthz", method: RequestMethod.GET },
+        { path: "readyz", method: RequestMethod.GET },
+      ],
+    })
   }
   app.enableCors()
 


### PR DESCRIPTION
## Migration scope
- preserve the exact EKS production commit as the base
- add process liveness and read-only readiness probes
- remove automatic database migration from startup
- run as non-root with a direct application entrypoint
- replace long-lived AWS keys and EKS deployment with the central GitHub OIDC workflow
- keep schedulers/workers disabled in EC2 test slots

## Gate
Draft only. Do not merge until OIDC, Secrets Manager, immutable image digest, and EC2 temporary-domain verification are ready.