### PR TITLE
chore: prepare lanting bio backend for EC2 runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.env*
+node_modules
+dist
+coverage
+*.log
+test
+test-github-oauth.html
+scripts
+README.md

--- a/.env.bio.example
+++ b/.env.bio.example
@@ -64,6 +64,7 @@ FRONTEND_URL="http://localhost:3000"
 
 #===============================================================================
 # Email IMAP
+EMAIL_WORKER_ENABLED=false
 #===============================================================================
 EMAIL_HOST=imap.example.com
 EMAIL_PORT=993

--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,7 @@ FRONTEND_URL="http://localhost:3000"
 
 #===============================================================================
 # Email IMAP
+EMAIL_WORKER_ENABLED=false
 #===============================================================================
 EMAIL_HOST=imap.example.com
 EMAIL_PORT=993

--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,7 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=
 REDIS_DB=2
+REDIS_TLS=false
 
 #===============================================================================
 # Swagger

--- a/.github/workflows/node-deploy-bio-staging.yml
+++ b/.github/workflows/node-deploy-bio-staging.yml
@@ -1,55 +1,16 @@
-# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
-# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
-# 5509
-
-name: bio staging deployment
+name: Validate dev-bio
 
 on:
   push:
     branches:
       - dev-bio
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
     steps:
       - uses: actions/checkout@v4
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-southeast-1
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Build, tag, and push image to Amazon ECR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: lanting-backend
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      - name: deploy to cluster
-        uses: kodermax/kubectl-aws-eks@main
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: lanting-backend
-          ECR_CONTAINER_NAME: lanting-backend-bio-staging
-          IMAGE_TAG: ${{ github.sha }}
-        with:
-          args: set image --namespace="lanting" deployment/$ECR_CONTAINER_NAME $ECR_CONTAINER_NAME=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      - name: verify deployment
-        uses: kodermax/kubectl-aws-eks@main
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
-          ECR_CONTAINER_NAME: lanting-backend-bio-staging
-        with:
-          args: rollout status deployment/$ECR_CONTAINER_NAME --namespace="lanting"
+      - run: docker build --platform linux/amd64 .

--- a/.github/workflows/node-deploy-bio.yml
+++ b/.github/workflows/node-deploy-bio.yml
@@ -1,7 +1,4 @@
-# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
-# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
-
-name: bio deployment
+name: Deploy lanting-backend-bio
 
 on:
   push:
@@ -9,46 +6,15 @@ on:
       - bio
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  deploy:
     permissions:
       contents: read
-      packages: write
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-southeast-1
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Build, tag, and push image to Amazon ECR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: lanting-backend
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      - name: deploy to cluster
-        uses: kodermax/kubectl-aws-eks@main
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: lanting-backend
-          ECR_CONTAINER_NAME: lanting-backend-bio
-          IMAGE_TAG: ${{ github.sha }}
-        with:
-          args: set image --namespace="lanting" deployment/$ECR_CONTAINER_NAME $ECR_CONTAINER_NAME=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      - name: verify deployment
-        uses: kodermax/kubectl-aws-eks@main
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
-          ECR_CONTAINER_NAME: lanting-backend-bio
-        with:
-          args: rollout status deployment/$ECR_CONTAINER_NAME --namespace="lanting"
+      id-token: write
+    uses: id-life/aws-runtime/.github/workflows/deploy-service.yml@main
+    with:
+      service: lanting-backend-bio
+      ecr_repository: lanting-backend
+      docker_context: .
+      dockerfile: Dockerfile
+      release_id: ${{ github.sha }}
+      aws_role_arn: ${{ vars.AWS_DEPLOY_ROLE_ARN }}

--- a/.github/workflows/node-deploy-bio.yml
+++ b/.github/workflows/node-deploy-bio.yml
@@ -7,14 +7,95 @@ on:
 
 jobs:
   deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: production
     permissions:
       contents: read
       id-token: write
-    uses: id-life/aws-runtime/.github/workflows/deploy-service.yml@main
-    with:
-      service: lanting-backend-bio
-      ecr_repository: lanting-backend
-      docker_context: .
-      dockerfile: Dockerfile
-      release_id: ${{ github.sha }}
-      aws_role_arn: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+    concurrency:
+      group: production-lanting-backend-bio
+      cancel-in-progress: false
+    env:
+      AWS_REGION: ap-southeast-1
+      SERVICE: lanting-backend-bio
+      ECR_REPOSITORY: lanting-backend
+      RELEASE_ID: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate immutable deployment inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$SERVICE" == "lanting-backend-bio" ]]
+          [[ "$ECR_REPOSITORY" == "lanting-backend" ]]
+          [[ "$RELEASE_ID" =~ ^[a-f0-9]{40}$ ]]
+          [[ "$RELEASE_ID" == "$GITHUB_SHA" ]]
+      - uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN || 'arn:aws:iam::550939689070:role/id-life-github-runtime-deploy' }}
+          aws-region: ${{ env.AWS_REGION }}
+      - id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - uses: docker/setup-buildx-action@v3
+      - name: Build and push amd64 image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: true
+          provenance: mode=max
+          sbom: true
+          tags: ${{ steps.ecr.outputs.registry }}/lanting-backend:${{ github.sha }}
+      - name: Deploy immutable digest through service-scoped SSM document
+        id: deploy
+        shell: bash
+        env:
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+          REGISTRY: ${{ steps.ecr.outputs.registry }}
+        run: |
+          set -euo pipefail
+          [[ "$IMAGE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]
+          image="$REGISTRY/$ECR_REPOSITORY@$IMAGE_DIGEST"
+          document="id-life-deploy-$SERVICE"
+          jq -n --arg image "$image" --arg release "$RELEASE_ID" \
+            '{image:[$image],releaseId:[$release],deployRole:["test"],schedulerBatonConfirmed:["false"]}' > parameters.json
+          command_id="$(aws ssm send-command \
+            --document-name "$document" \
+            --targets 'Key=tag:Project,Values=id-life' 'Key=tag:Environment,Values=production' \
+            --parameters file://parameters.json \
+            --max-concurrency 1 \
+            --max-errors 0 \
+            --query 'Command.CommandId' \
+            --output text)"
+          echo "command_id=$command_id" >> "$GITHUB_OUTPUT"
+          instance_id=""
+          for attempt in $(seq 1 60); do
+            instance_id="$(aws ssm list-command-invocations --command-id "$command_id" --query 'CommandInvocations[0].InstanceId' --output text)"
+            [[ "$instance_id" =~ ^i-[a-f0-9]+$ ]] && break
+            sleep 2
+          done
+          [[ "$instance_id" =~ ^i-[a-f0-9]+$ ]]
+          status="Pending"
+          for attempt in $(seq 1 180); do
+            status="$(aws ssm get-command-invocation --command-id "$command_id" --instance-id "$instance_id" --query Status --output text)"
+            case "$status" in
+              Success) break ;;
+              Failed|TimedOut|Cancelled|Cancelling) exit 1 ;;
+            esac
+            sleep 5
+          done
+          [[ "$status" == "Success" ]]
+      - name: Record deployment summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### EC2 deployment"
+            echo "- Service: \`$SERVICE\`"
+            echo "- Release: \`$RELEASE_ID\`"
+            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "- SSM command: \`${{ steps.deploy.outputs.command_id }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,78 @@
-FROM node:22-slim AS builder
+# syntax=docker/dockerfile:1.7
+
+FROM node:22-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS builder
+
+ENV SCARF_ANALYTICS=false
 
 WORKDIR /app
+RUN set -eu; \
+    for attempt in 1 2 3 4 5; do \
+      if apt-get -o Acquire::Retries=5 update \
+        && apt-get -o Acquire::Retries=5 install -y --no-install-recommends openssl; then \
+        rm -rf /var/lib/apt/lists/*; \
+        break; \
+      fi; \
+      rm -rf /var/lib/apt/lists/*; \
+      if [ "$attempt" = 5 ]; then exit 1; fi; \
+      sleep "$((attempt * 2))"; \
+    done
+RUN set -eu; \
+    corepack enable; \
+    for attempt in 1 2 3 4 5; do \
+      if corepack prepare pnpm@10.11.0 --activate; then break; fi; \
+      if [ "$attempt" = 5 ]; then exit 1; fi; \
+      sleep "$((attempt * 2))"; \
+    done
 
-COPY package*.json pnpm-*.yaml ./
-COPY prisma ./prisma/
-
-RUN corepack enable && \
-    npm install @antfu/ni -g
-RUN nci
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY prisma ./prisma
+RUN --mount=type=cache,id=lanting-backend-bio-pnpm,target=/root/.local/share/pnpm/store \
+    --mount=type=cache,id=lanting-backend-bio-prisma,target=/root/.cache/prisma \
+    pnpm install --frozen-lockfile --ignore-scripts
+RUN --mount=type=cache,id=lanting-backend-bio-prisma,target=/root/.cache/prisma \
+    set -eu; \
+    for attempt in 1 2 3 4 5; do \
+      if pnpm rebuild @prisma/client @prisma/engines @swc/core esbuild prisma unrs-resolver; then break; fi; \
+      if [ "$attempt" = 5 ]; then exit 1; fi; \
+      sleep "$((attempt * 2))"; \
+    done
 
 COPY . .
+RUN --mount=type=cache,id=lanting-backend-bio-prisma,target=/root/.cache/prisma \
+    pnpm prisma:generate
+RUN pnpm test:migration \
+    && pnpm build \
+    && pnpm prune --prod --ignore-scripts
 
-RUN npm run build
+FROM node:22-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS runtime
 
-FROM node:22-slim
+RUN set -eu; \
+    for attempt in 1 2 3 4 5; do \
+      if apt-get -o Acquire::Retries=5 update \
+        && apt-get -o Acquire::Retries=5 install -y --no-install-recommends ca-certificates chromium openssl; then \
+        rm -rf /var/lib/apt/lists/*; \
+        break; \
+      fi; \
+      rm -rf /var/lib/apt/lists/*; \
+      if [ "$attempt" = 5 ]; then exit 1; fi; \
+      sleep "$((attempt * 2))"; \
+    done
 
-RUN apt-get update && apt-get install -y \
-    openssl \
-    wget \
-    ca-certificates \
-    && wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-    && dpkg -i google-chrome-stable_current_amd64.deb || true \
-    && apt-get install -f -y \
-    && rm google-chrome-stable_current_amd64.deb \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV CHROME_BIN=/usr/bin/google-chrome
+ENV NODE_ENV=production \
+    PORT=8000 \
+    CHROME_BIN=/usr/bin/chromium \
+    EMAIL_WORKER_ENABLED=false
 
 WORKDIR /app
+COPY --from=builder --chown=node:node /app/node_modules ./node_modules
+COPY --from=builder --chown=node:node /app/package.json ./package.json
+COPY --from=builder --chown=node:node /app/dist ./dist
+COPY --from=builder --chown=node:node /app/prisma ./prisma
+RUN install -d -o node -g node -m 0750 /app/data /tmp/lanting-chromium
 
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/package*.json ./
-COPY --from=builder /app/pnpm-*.yaml ./
-COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/prisma ./prisma
+USER node
+EXPOSE 8000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD ["node", "-e", "fetch('http://127.0.0.1:8000/healthz').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
 
-EXPOSE 3000
-CMD [ "npm", "run", "start:prod" ]
+CMD ["node", "dist/main"]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "prisma migrate deploy && node dist/main",
+    "start:prod": "node dist/main",
+    "test:migration": "jest --runInBand --detectOpenHandles app.controller.spec.ts health/health.controller.spec.ts common/imapflow/imapflow.migration.spec.ts config/schema.migration.spec.ts",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
@@ -114,6 +115,9 @@
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/$1"
     },
     "collectCoverageFrom": [
       "**/*.(t|j)s"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,7 @@
 onlyBuiltDependencies:
-  - "@nestjs/core"
   - "@prisma/client"
   - "@prisma/engines"
-  - "@scarf/scarf"
   - "@swc/core"
   - esbuild
   - prisma
-  - simple-git-hooks
   - unrs-resolver

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -15,8 +15,8 @@ describe("appController", () => {
   })
 
   describe("root", () => {
-    it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe("Hello World!")
+    it("returns the service welcome message", () => {
+      expect(appController.getHello()).toBe("Welcome to lanting-backend!")
     })
   })
 })

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { AuthModule } from "./auth/auth.module"
 import { CommonModule } from "./common/common.module"
 import { ConfigModule } from "./config/config.module"
 import { EmailModule } from "./email/email.module"
+import { HealthModule } from "./health/health.module"
 import { TributeModule } from "./tribute/tribute.module"
 
 @Module({
@@ -18,6 +19,7 @@ import { TributeModule } from "./tribute/tribute.module"
     CommonModule,
     EmailModule,
     AuthModule,
+    HealthModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/common/imapflow/imapflow.migration.spec.ts
+++ b/src/common/imapflow/imapflow.migration.spec.ts
@@ -1,0 +1,31 @@
+import { ImapflowService } from "./imapflow.service"
+
+describe("ImapflowService migration gate", () => {
+  function create(enabled: boolean) {
+    const config = { emailWorkerEnabled: enabled }
+    return new ImapflowService(config as any, {} as any, {} as any)
+  }
+
+  it("does not initialize email or scheduled work in web slots", async () => {
+    const service = create(false)
+    const initialize = jest
+      .spyOn(service as any, "initializeEmail")
+      .mockResolvedValue(undefined)
+
+    await service.onModuleInit()
+    await service.checkSpamEmails()
+
+    expect(initialize).not.toHaveBeenCalled()
+  })
+
+  it("initializes email only for the explicitly enabled worker", async () => {
+    const service = create(true)
+    const initialize = jest
+      .spyOn(service as any, "initializeEmail")
+      .mockResolvedValue(undefined)
+
+    await service.onModuleInit()
+
+    expect(initialize).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/common/imapflow/imapflow.service.ts
+++ b/src/common/imapflow/imapflow.service.ts
@@ -55,6 +55,10 @@ export class ImapflowService implements OnModuleInit, OnModuleDestroy {
   ) {}
 
   async onModuleInit() {
+    if (!this.configService.emailWorkerEnabled) {
+      this.logger.log("Email worker disabled")
+      return
+    }
     this.logger.log("ImapflowService initializing...")
     await this.initializeEmail()
   }
@@ -411,6 +415,9 @@ export class ImapflowService implements OnModuleInit, OnModuleDestroy {
    */
   @Cron(CronExpression.EVERY_5_MINUTES)
   async checkSpamEmails() {
+    if (!this.configService.emailWorkerEnabled) {
+      return
+    }
     if (!this.client) {
       return
     }

--- a/src/common/redis/redis.module.ts
+++ b/src/common/redis/redis.module.ts
@@ -11,7 +11,11 @@ import { RedisService } from "./redis.service"
     CacheModule.registerAsync({
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => {
-        const redisUrl = `redis://${configService.redisPassword ? `${configService.redisPassword}@` : ""}${configService.redisHost}:${configService.redisPort}/${configService.redisDb}`
+        const protocol = configService.redisTls ? "rediss" : "redis"
+        const password = configService.redisPassword
+          ? `:${encodeURIComponent(configService.redisPassword)}@`
+          : ""
+        const redisUrl = `${protocol}://${password}${configService.redisHost}:${configService.redisPort}/${configService.redisDb}`
 
         const keyvRedis = new KeyvRedis(redisUrl)
 

--- a/src/common/redis/redis.service.ts
+++ b/src/common/redis/redis.service.ts
@@ -19,6 +19,10 @@ export class RedisService {
       redisConfig.password = this.configService.redisPassword
     }
 
+    if (this.configService.redisTls) {
+      redisConfig.tls = {}
+    }
+
     this.client = new Redis(redisConfig)
 
     this.client.on("connect", () => {

--- a/src/config/config.service.spec.ts
+++ b/src/config/config.service.spec.ts
@@ -1,0 +1,26 @@
+import { ConfigService } from "./config.service"
+
+describe("ConfigService Redis TLS", () => {
+  const service = (values: Record<string, unknown>) =>
+    new ConfigService({
+      get: (key: string) => values[key],
+    } as never)
+
+  it("automatically enables TLS for AWS ElastiCache endpoints", () => {
+    expect(
+      service({
+        "app.REDIS_HOST": "master.example.cache.amazonaws.com",
+        "app.REDIS_TLS": undefined,
+      }).redisTls,
+    ).toBe(true)
+  })
+
+  it("honors an explicit override for non-AWS or local Redis", () => {
+    expect(
+      service({
+        "app.REDIS_HOST": "localhost",
+        "app.REDIS_TLS": false,
+      }).redisTls,
+    ).toBe(false)
+  })
+})

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -71,6 +71,13 @@ export class ConfigService {
     return this.nestConfigService.get("app.REDIS_DB", { infer: true })
   }
 
+  get redisTls() {
+    const configured = this.nestConfigService.get("app.REDIS_TLS", {
+      infer: true,
+    })
+    return configured ?? this.redisHost.endsWith(".cache.amazonaws.com")
+  }
+
   get swaggerEnabled() {
     return this.nestConfigService.get("app.SWAGGER_ENABLED", { infer: true })
   }

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -114,4 +114,10 @@ export class ConfigService {
   get emailPassword() {
     return this.nestConfigService.get("app.EMAIL_PASSWORD", { infer: true })
   }
+
+  get emailWorkerEnabled() {
+    return this.nestConfigService.get("app.EMAIL_WORKER_ENABLED", {
+      infer: true,
+    })
+  }
 }

--- a/src/config/schema.migration.spec.ts
+++ b/src/config/schema.migration.spec.ts
@@ -1,0 +1,18 @@
+import { appConfigSchema } from "./schema"
+
+describe("migration runtime configuration", () => {
+  const base = { JWT_SECRET: "x".repeat(32) }
+
+  it("keeps the email listener and scheduler disabled by default", () => {
+    expect(appConfigSchema.parse(base).EMAIL_WORKER_ENABLED).toBe(false)
+  })
+
+  it("requires an explicit true value to enable the email worker", () => {
+    expect(
+      appConfigSchema.parse({
+        ...base,
+        EMAIL_WORKER_ENABLED: "true",
+      }).EMAIL_WORKER_ENABLED,
+    ).toBe(true)
+  })
+})

--- a/src/config/schema.spec.ts
+++ b/src/config/schema.spec.ts
@@ -1,0 +1,14 @@
+import { appConfigSchema } from "./schema"
+
+describe("Redis TLS configuration", () => {
+  const base = { JWT_SECRET: "x".repeat(32) }
+
+  it("leaves TLS unset for host-based ElastiCache detection", () => {
+    expect(appConfigSchema.parse(base).REDIS_TLS).toBeUndefined()
+    expect(appConfigSchema.parse({ ...base, REDIS_TLS: "false" }).REDIS_TLS).toBe(false)
+  })
+
+  it("enables TLS for ElastiCache when explicitly configured", () => {
+    expect(appConfigSchema.parse({ ...base, REDIS_TLS: "true" }).REDIS_TLS).toBe(true)
+  })
+})

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -55,6 +55,10 @@ export const appConfigSchema = z.object({
   EMAIL_PORT: z.coerce.number().optional(),
   EMAIL_USERNAME: z.string().optional(),
   EMAIL_PASSWORD: z.string().optional(),
+  EMAIL_WORKER_ENABLED: z
+    .enum(["true", "false"])
+    .default("false")
+    .transform((value) => value === "true"),
 })
 
 export type AppConfig = z.infer<typeof appConfigSchema>

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -33,6 +33,10 @@ export const appConfigSchema = z.object({
   REDIS_PORT: z.coerce.number().default(6379),
   REDIS_PASSWORD: z.string().optional(),
   REDIS_DB: z.coerce.number().default(0),
+  REDIS_TLS: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((value) => (value === undefined ? undefined : value === "true")),
 
   // swagger
   SWAGGER_ENABLED: z

--- a/src/health/health.controller.spec.ts
+++ b/src/health/health.controller.spec.ts
@@ -1,0 +1,47 @@
+import { HealthController } from "./health.controller"
+
+describe("HealthController migration contract", () => {
+  const status = jest.fn()
+  const response = { status } as any
+  const prisma = { $queryRawUnsafe: jest.fn() }
+  const redisClient = { ping: jest.fn() }
+  const redis = { getClient: () => redisClient }
+  const controller = new HealthController(prisma as any, redis as any)
+
+  beforeEach(() => jest.clearAllMocks())
+
+  it("keeps liveness dependency-free", () => {
+    expect(controller.healthz()).toEqual({
+      ok: true,
+      service: "lanting-backend-bio",
+    })
+    expect(prisma.$queryRawUnsafe).not.toHaveBeenCalled()
+    expect(redisClient.ping).not.toHaveBeenCalled()
+  })
+
+  it("uses read-only dependency checks for readiness", async () => {
+    prisma.$queryRawUnsafe.mockResolvedValue([{ 1: 1 }])
+    redisClient.ping.mockResolvedValue("PONG")
+
+    await expect(controller.readyz(response)).resolves.toEqual({
+      ok: true,
+      database: true,
+      redis: true,
+    })
+    expect(prisma.$queryRawUnsafe).toHaveBeenCalledWith("SELECT 1")
+    expect(redisClient.ping).toHaveBeenCalledTimes(1)
+    expect(status).not.toHaveBeenCalled()
+  })
+
+  it("fails closed without exposing dependency errors", async () => {
+    prisma.$queryRawUnsafe.mockRejectedValue(new Error("sensitive detail"))
+    redisClient.ping.mockResolvedValue("PONG")
+
+    await expect(controller.readyz(response)).resolves.toEqual({
+      ok: false,
+      database: false,
+      redis: false,
+    })
+    expect(status).toHaveBeenCalledWith(503)
+  })
+})

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,0 +1,55 @@
+import { Controller, Get, Res } from "@nestjs/common"
+import type { Response } from "express"
+import { PrismaService } from "../common/prisma/prisma.service"
+import { RedisService } from "../common/redis/redis.service"
+
+const READY_TIMEOUT_MS = 2_000
+
+function withTimeout<T>(promise: Promise<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error("readiness timeout")),
+      READY_TIMEOUT_MS,
+    )
+
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (error) => {
+        clearTimeout(timer)
+        reject(error)
+      },
+    )
+  })
+}
+
+@Controller()
+export class HealthController {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly redis: RedisService,
+  ) {}
+
+  @Get("healthz")
+  healthz() {
+    return { ok: true, service: "lanting-backend-bio" }
+  }
+
+  @Get("readyz")
+  async readyz(@Res({ passthrough: true }) response: Response) {
+    try {
+      await withTimeout(
+        Promise.all([
+          this.prisma.$queryRawUnsafe("SELECT 1"),
+          this.redis.getClient().ping(),
+        ]),
+      )
+      return { ok: true, database: true, redis: true }
+    } catch {
+      response.status(503)
+      return { ok: false, database: false, redis: false }
+    }
+  }
+}

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -1,0 +1,5 @@
+import { Module } from "@nestjs/common"
+import { HealthController } from "./health.controller"
+
+@Module({ controllers: [HealthController] })
+export class HealthModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Logger, ValidationPipe } from "@nestjs/common"
+import { Logger, RequestMethod, ValidationPipe } from "@nestjs/common"
 import { NestFactory } from "@nestjs/core"
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger"
 import { AppModule } from "./app.module"
@@ -19,7 +19,12 @@ async function bootstrap() {
   )
 
   if (configService.apiPrefix) {
-    app.setGlobalPrefix(configService.apiPrefix)
+    app.setGlobalPrefix(configService.apiPrefix, {
+      exclude: [
+        { path: "healthz", method: RequestMethod.GET },
+        { path: "readyz", method: RequestMethod.GET },
+      ],
+    })
   }
   app.enableCors()
 


### PR DESCRIPTION
## Migration scope
- preserve the exact EKS production commit as the base
- add process liveness and read-only readiness probes
- remove automatic database migration from startup
- run as non-root with a direct application entrypoint
- replace long-lived AWS keys and EKS deployment with the central GitHub OIDC workflow
- keep schedulers/workers disabled in EC2 test slots

## Gate
Draft only. Do not merge until OIDC, Secrets Manager, immutable image digest, and EC2 temporary-domain verification are ready.