### PR TITLE
Use TLS for ElastiCache Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,7 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=
 REDIS_DB=2
+REDIS_TLS=false
 
 #===============================================================================
 # Swagger

--- a/src/common/redis/redis.module.ts
+++ b/src/common/redis/redis.module.ts
@@ -11,7 +11,11 @@ import { RedisService } from "./redis.service"
     CacheModule.registerAsync({
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => {
-        const redisUrl = `redis://${configService.redisPassword ? `${configService.redisPassword}@` : ""}${configService.redisHost}:${configService.redisPort}/${configService.redisDb}`
+        const protocol = configService.redisTls ? "rediss" : "redis"
+        const password = configService.redisPassword
+          ? `:${encodeURIComponent(configService.redisPassword)}@`
+          : ""
+        const redisUrl = `${protocol}://${password}${configService.redisHost}:${configService.redisPort}/${configService.redisDb}`
 
         const keyvRedis = new KeyvRedis(redisUrl)
 

--- a/src/common/redis/redis.service.ts
+++ b/src/common/redis/redis.service.ts
@@ -19,6 +19,10 @@ export class RedisService {
       redisConfig.password = this.configService.redisPassword
     }
 
+    if (this.configService.redisTls) {
+      redisConfig.tls = {}
+    }
+
     this.client = new Redis(redisConfig)
 
     this.client.on("connect", () => {

--- a/src/config/config.service.spec.ts
+++ b/src/config/config.service.spec.ts
@@ -1,0 +1,26 @@
+import { ConfigService } from "./config.service"
+
+describe("ConfigService Redis TLS", () => {
+  const service = (values: Record<string, unknown>) =>
+    new ConfigService({
+      get: (key: string) => values[key],
+    } as never)
+
+  it("automatically enables TLS for AWS ElastiCache endpoints", () => {
+    expect(
+      service({
+        "app.REDIS_HOST": "master.example.cache.amazonaws.com",
+        "app.REDIS_TLS": undefined,
+      }).redisTls,
+    ).toBe(true)
+  })
+
+  it("honors an explicit override for non-AWS or local Redis", () => {
+    expect(
+      service({
+        "app.REDIS_HOST": "localhost",
+        "app.REDIS_TLS": false,
+      }).redisTls,
+    ).toBe(false)
+  })
+})

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -71,6 +71,13 @@ export class ConfigService {
     return this.nestConfigService.get("app.REDIS_DB", { infer: true })
   }
 
+  get redisTls() {
+    const configured = this.nestConfigService.get("app.REDIS_TLS", {
+      infer: true,
+    })
+    return configured ?? this.redisHost.endsWith(".cache.amazonaws.com")
+  }
+
   get swaggerEnabled() {
     return this.nestConfigService.get("app.SWAGGER_ENABLED", { infer: true })
   }

--- a/src/config/schema.spec.ts
+++ b/src/config/schema.spec.ts
@@ -1,0 +1,14 @@
+import { appConfigSchema } from "./schema"
+
+describe("Redis TLS configuration", () => {
+  const base = { JWT_SECRET: "x".repeat(32) }
+
+  it("leaves TLS unset for host-based ElastiCache detection", () => {
+    expect(appConfigSchema.parse(base).REDIS_TLS).toBeUndefined()
+    expect(appConfigSchema.parse({ ...base, REDIS_TLS: "false" }).REDIS_TLS).toBe(false)
+  })
+
+  it("enables TLS for ElastiCache when explicitly configured", () => {
+    expect(appConfigSchema.parse({ ...base, REDIS_TLS: "true" }).REDIS_TLS).toBe(true)
+  })
+})

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -33,6 +33,10 @@ export const appConfigSchema = z.object({
   REDIS_PORT: z.coerce.number().default(6379),
   REDIS_PASSWORD: z.string().optional(),
   REDIS_DB: z.coerce.number().default(0),
+  REDIS_TLS: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((value) => (value === undefined ? undefined : value === "true")),
 
   // swagger
   SWAGGER_ENABLED: z


### PR DESCRIPTION
## Summary
- automatically enable Redis TLS for AWS ElastiCache endpoints
- keep an explicit `REDIS_TLS=false` override for local/plaintext Redis
- use `rediss://` for the cache-manager client and TLS options for ioredis

## Evidence
- ElastiCache production requires transit encryption and auth
- EC2 TCP probes reach database and Redis; database `SELECT 1` succeeds
- 7 focused tests pass and Nest build passes
- no Secret, database, Route 53, or EKS change