### PR TITLE
Harden public EC2 deployment workflow

### DIFF
--- a/.github/workflows/deploy-service-ec2.yml
+++ b/.github/workflows/deploy-service-ec2.yml
@@ -1,0 +1,279 @@
+name: Deploy service to EC2
+
+on:
+  workflow_call:
+    inputs:
+      service:
+        description: Catalog service id
+        required: true
+        type: string
+      ecr_repository:
+        description: ECR repository name owned by the caller role
+        required: true
+        type: string
+      docker_context:
+        required: false
+        default: .
+        type: string
+      dockerfile:
+        required: false
+        default: Dockerfile
+        type: string
+      release_id:
+        description: Full Git commit SHA
+        required: true
+        type: string
+      aws_role_arn:
+        description: Optional exact repository-scoped GitHub OIDC role override
+        required: false
+        default: ''
+        type: string
+      deploy_role:
+        description: inherit preserves the active role; production/test are explicit role changes
+        required: false
+        default: inherit
+        type: string
+      scheduler_baton_confirmed:
+        description: Confirm that the old scheduler is stopped before first production activation
+        required: false
+        default: false
+        type: boolean
+      allow_scheduler_disable:
+        description: Explicit confirmation required when changing an active production service to test
+        required: false
+        default: false
+        type: boolean
+      smoke_url:
+        description: Optional public HTTPS health/readiness URL checked after SSM succeeds
+        required: false
+        default: ''
+        type: string
+      smoke_expected_status:
+        description: Exact HTTP status required from smoke_url
+        required: false
+        default: 200
+        type: number
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: production-${{ inputs.service }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: production
+    env:
+      AWS_REGION: ap-southeast-1
+      SERVICE: ${{ inputs.service }}
+      ECR_REPOSITORY: ${{ inputs.ecr_repository }}
+      RELEASE_ID: ${{ inputs.release_id }}
+      DEPLOY_ROLE: ${{ inputs.deploy_role }}
+      SMOKE_URL: ${{ inputs.smoke_url }}
+      SMOKE_EXPECTED_STATUS: ${{ inputs.smoke_expected_status }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - name: Validate immutable deployment inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$SERVICE" =~ ^[a-z0-9][a-z0-9-]+$ ]]
+          [[ "$ECR_REPOSITORY" =~ ^[A-Za-z0-9._/-]+$ ]]
+          [[ "$RELEASE_ID" =~ ^[a-f0-9]{40}$ ]]
+          [[ "$RELEASE_ID" == "$GITHUB_SHA" ]]
+          [[ "$DEPLOY_ROLE" == "inherit" || "$DEPLOY_ROLE" == "test" || "$DEPLOY_ROLE" == "production" ]]
+          if [[ "${{ inputs.allow_scheduler_disable }}" == "true" && "$DEPLOY_ROLE" != "test" ]]; then
+            echo "allow_scheduler_disable is valid only with deploy_role=test" >&2
+            exit 2
+          fi
+          if [[ "${{ inputs.scheduler_baton_confirmed }}" == "true" && "$DEPLOY_ROLE" != "production" ]]; then
+            echo "scheduler_baton_confirmed is valid only with deploy_role=production" >&2
+            exit 2
+          fi
+          if [[ -n "$SMOKE_URL" && ! "$SMOKE_URL" =~ ^https://[A-Za-z0-9.-]+(/[^[:space:]]*)?$ ]]; then
+            echo "smoke_url must be an HTTPS URL without credentials or a custom port" >&2
+            exit 2
+          fi
+          [[ "$SMOKE_EXPECTED_STATUS" =~ ^[1-5][0-9]{2}$ ]]
+      - name: Select repository-scoped AWS role
+        id: aws-role
+        shell: bash
+        env:
+          EXPLICIT_ROLE_ARN: ${{ inputs.aws_role_arn }}
+        run: |
+          set -euo pipefail
+          expected_role_arn="arn:aws:iam::550939689070:role/id-life-github-deploy-$SERVICE"
+          role_arn="${EXPLICIT_ROLE_ARN:-$expected_role_arn}"
+          [[ "$role_arn" == "$expected_role_arn" ]]
+          echo "role_arn=$role_arn" >> "$GITHUB_OUTPUT"
+      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+        with:
+          role-to-assume: ${{ steps.aws-role.outputs.role_arn }}
+          aws-region: ${{ env.AWS_REGION }}
+      - id: ecr
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Build and push amd64 image
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: ${{ inputs.docker_context }}
+          file: ${{ inputs.dockerfile }}
+          platforms: linux/amd64
+          push: true
+          provenance: mode=max
+          sbom: true
+          tags: ${{ steps.ecr.outputs.registry }}/${{ inputs.ecr_repository }}:${{ inputs.release_id }}
+      - name: Deploy immutable digest through service-scoped SSM document
+        id: deploy
+        shell: bash
+        env:
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+          REGISTRY: ${{ steps.ecr.outputs.registry }}
+          ALLOW_SCHEDULER_DISABLE: ${{ inputs.allow_scheduler_disable }}
+          SCHEDULER_BATON_CONFIRMED: ${{ inputs.scheduler_baton_confirmed }}
+        run: |
+          set -euo pipefail
+          [[ "$IMAGE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]
+          image="$REGISTRY/$ECR_REPOSITORY@$IMAGE_DIGEST"
+          document="id-life-deploy-$SERVICE"
+
+          # Resolve and assert the singleton target before sending a command.
+          # This prevents a tag mistake or a replacement overlap from deploying
+          # to multiple hosts while the workflow watches only one invocation.
+          # SSM rejects tag filters mixed with PingStatus (and, depending on
+          # API generation, multiple tag filters). Discover by one tag, select
+          # online managed nodes locally, then use EC2 for the exact second tag
+          # and running-state assertion.
+          managed_instances="$(aws ssm describe-instance-information \
+            --filters 'Key=tag:Project,Values=id-life' \
+            --output json)"
+          mapfile -t online_instance_ids < <(jq -r \
+            '.InstanceInformationList[] | select(.PingStatus == "Online") | .InstanceId' \
+            <<<"$managed_instances")
+          instance_ids=()
+          if (( ${#online_instance_ids[@]} > 0 )); then
+            exact_instances="$(aws ec2 describe-instances \
+              --instance-ids "${online_instance_ids[@]}" \
+              --filters \
+                'Name=tag:Project,Values=id-life' \
+                'Name=tag:Environment,Values=production' \
+                'Name=instance-state-name,Values=running' \
+              --output json)"
+            mapfile -t instance_ids < <(jq -r \
+              '.Reservations[].Instances[].InstanceId' <<<"$exact_instances")
+          fi
+          if (( ${#instance_ids[@]} != 1 )); then
+            echo "::error title=Unsafe runtime target set::expected exactly one online production runtime host, found ${#instance_ids[@]}"
+            exit 1
+          fi
+          instance_id="${instance_ids[0]}"
+          [[ "$instance_id" =~ ^i-[a-f0-9]+$ ]]
+
+          jq -n --arg image "$image" --arg release "$RELEASE_ID" \
+            --arg role "$DEPLOY_ROLE" \
+            --arg baton "$SCHEDULER_BATON_CONFIRMED" \
+            --arg allow_disable "$ALLOW_SCHEDULER_DISABLE" \
+            '{image:[$image],releaseId:[$release],deployRole:[$role],schedulerBatonConfirmed:[$baton],allowSchedulerDisable:[$allow_disable]}' > parameters.json
+          command_id="$(aws ssm send-command \
+            --document-name "$document" \
+            --instance-ids "$instance_id" \
+            --parameters file://parameters.json \
+            --max-concurrency 1 \
+            --max-errors 0 \
+            --query 'Command.CommandId' \
+            --output text)"
+          echo "command_id=$command_id" >> "$GITHUB_OUTPUT"
+
+          report_invocation_failure() {
+            local invocation_id="$1" result safe_output
+            result="$(aws ssm get-command-invocation \
+              --command-id "$command_id" \
+              --instance-id "$invocation_id" \
+              --output json)"
+            jq -r '"::error title=SSM deployment failed::instance=\(.InstanceId) status=\(.Status) detail=\(.StatusDetails // "unknown") response=\(.ResponseCode // -1)"' <<<"$result"
+            # idctl never logs environment values, but redact common credential
+            # shapes as a second boundary and cap diagnostic output to 4 KiB.
+            safe_output="$(jq -r '[.StandardErrorContent, .StandardOutputContent] | map(select(type == "string" and length > 0)) | join("\n") | .[0:4096]' <<<"$result" \
+              | sed -E \
+                  -e 's/(AKIA|ASIA)[A-Z0-9]{16}/[REDACTED_AWS_ACCESS_KEY]/g' \
+                  -e 's/([Pp]assword|[Ss]ecret|[Tt]oken|[Aa]uthorization)(["'"'"'=: ]+)[^ ,;]+/\1\2[REDACTED]/g')"
+            if [[ -n "$safe_output" ]]; then
+              echo "::group::Sanitized SSM diagnostic for $invocation_id"
+              while IFS= read -r line; do printf '| %s\n' "$line"; done <<<"$safe_output"
+              echo "::endgroup::"
+            fi
+          }
+
+          completed=false
+          for attempt in $(seq 1 360); do
+            invocations="$(aws ssm list-command-invocations \
+              --command-id "$command_id" \
+              --details \
+              --output json)"
+            invocation_count="$(jq '.CommandInvocations | length' <<<"$invocations")"
+            if (( invocation_count > 1 )); then
+              echo "::error title=Unsafe SSM fan-out::command unexpectedly has $invocation_count invocations"
+              while IFS= read -r failed_instance; do report_invocation_failure "$failed_instance"; done \
+                < <(jq -r '.CommandInvocations[].InstanceId' <<<"$invocations")
+              exit 1
+            fi
+            if (( invocation_count == 1 )); then
+              status="$(jq -r '.CommandInvocations[0].Status' <<<"$invocations")"
+              case "$status" in
+                Success) completed=true; break ;;
+                Failed|TimedOut|Cancelled|Cancelling)
+                  report_invocation_failure "$instance_id"
+                  exit 1
+                  ;;
+              esac
+            fi
+            sleep 5
+          done
+          if [[ "$completed" != "true" ]]; then
+            echo "::error title=SSM deployment timed out::command did not complete within 30 minutes"
+            report_invocation_failure "$instance_id"
+            exit 1
+          fi
+
+      - name: Verify public ALB route
+        if: ${{ inputs.smoke_url != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual_status=""
+          for attempt in $(seq 1 12); do
+            actual_status="$(curl \
+              --proto '=https' \
+              --tlsv1.2 \
+              --silent \
+              --show-error \
+              --output /dev/null \
+              --write-out '%{http_code}' \
+              --connect-timeout 5 \
+              --max-time 15 \
+              "$SMOKE_URL" || true)"
+            [[ "$actual_status" == "$SMOKE_EXPECTED_STATUS" ]] && break
+            sleep 5
+          done
+          if [[ "$actual_status" != "$SMOKE_EXPECTED_STATUS" ]]; then
+            echo "::error title=Public smoke failed::expected HTTP $SMOKE_EXPECTED_STATUS, received ${actual_status:-network-error}"
+            exit 1
+          fi
+      - name: Record deployment summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### EC2 deployment"
+            echo "- Service: \`$SERVICE\`"
+            echo "- Release: \`$RELEASE_ID\`"
+            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "- Deploy role: \`$DEPLOY_ROLE\`"
+            echo "- SSM command: \`${{ steps.deploy.outputs.command_id }}\`"
+            if [[ -n "$SMOKE_URL" ]]; then echo "- Public smoke gate: HTTP $SMOKE_EXPECTED_STATUS passed"; fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/node-deploy-bio-staging.yml
+++ b/.github/workflows/node-deploy-bio-staging.yml
@@ -9,5 +9,5 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - run: docker build --platform linux/amd64 .

--- a/.github/workflows/node-deploy-bio.yml
+++ b/.github/workflows/node-deploy-bio.yml
@@ -10,11 +10,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: id-life/aws-runtime/.github/workflows/deploy-service.yml@main
+    uses: id-life/lanting-backend/.github/workflows/deploy-service-ec2.yml@main
     with:
       service: lanting-backend-bio
       ecr_repository: lanting-backend
-      docker_context: .
-      dockerfile: Dockerfile
       release_id: ${{ github.sha }}
-      aws_role_arn: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+      smoke_url: https://migration-lanting-bio-api.id.life/healthz

--- a/.github/workflows/node-deploy-main.yml
+++ b/.github/workflows/node-deploy-main.yml
@@ -5,97 +5,15 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    environment: production
-    permissions:
-      contents: read
-      id-token: write
-    concurrency:
-      group: production-lanting-backend
-      cancel-in-progress: false
-    env:
-      AWS_REGION: ap-southeast-1
-      SERVICE: lanting-backend
-      ECR_REPOSITORY: lanting-backend
-      RELEASE_ID: ${{ github.sha }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Validate immutable deployment inputs
-        shell: bash
-        run: |
-          set -euo pipefail
-          [[ "$SERVICE" == "lanting-backend" ]]
-          [[ "$ECR_REPOSITORY" == "lanting-backend" ]]
-          [[ "$RELEASE_ID" =~ ^[a-f0-9]{40}$ ]]
-          [[ "$RELEASE_ID" == "$GITHUB_SHA" ]]
-      - uses: aws-actions/configure-aws-credentials@v5
-        with:
-          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN || 'arn:aws:iam::550939689070:role/id-life-github-runtime-deploy' }}
-          aws-region: ${{ env.AWS_REGION }}
-      - id: ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - uses: docker/setup-buildx-action@v3
-      - name: Build and push amd64 image
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64
-          push: true
-          provenance: mode=max
-          sbom: true
-          tags: ${{ steps.ecr.outputs.registry }}/lanting-backend:${{ github.sha }}
-      - name: Deploy immutable digest through service-scoped SSM document
-        id: deploy
-        shell: bash
-        env:
-          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
-          REGISTRY: ${{ steps.ecr.outputs.registry }}
-        run: |
-          set -euo pipefail
-          [[ "$IMAGE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]
-          image="$REGISTRY/$ECR_REPOSITORY@$IMAGE_DIGEST"
-          document="id-life-deploy-$SERVICE"
-          jq -n --arg image "$image" --arg release "$RELEASE_ID" \
-            '{image:[$image],releaseId:[$release],deployRole:["test"],schedulerBatonConfirmed:["false"]}' > parameters.json
-          command_id="$(aws ssm send-command \
-            --document-name "$document" \
-            --targets 'Key=tag:Project,Values=id-life' 'Key=tag:Environment,Values=production' \
-            --parameters file://parameters.json \
-            --max-concurrency 1 \
-            --max-errors 0 \
-            --query 'Command.CommandId' \
-            --output text)"
-          echo "command_id=$command_id" >> "$GITHUB_OUTPUT"
-          instance_id=""
-          for attempt in $(seq 1 60); do
-            instance_id="$(aws ssm list-command-invocations --command-id "$command_id" --query 'CommandInvocations[0].InstanceId' --output text)"
-            [[ "$instance_id" =~ ^i-[a-f0-9]+$ ]] && break
-            sleep 2
-          done
-          [[ "$instance_id" =~ ^i-[a-f0-9]+$ ]]
-          status="Pending"
-          for attempt in $(seq 1 180); do
-            status="$(aws ssm get-command-invocation --command-id "$command_id" --instance-id "$instance_id" --query Status --output text)"
-            case "$status" in
-              Success) break ;;
-              Failed|TimedOut|Cancelled|Cancelling) exit 1 ;;
-            esac
-            sleep 5
-          done
-          [[ "$status" == "Success" ]]
-      - name: Record deployment summary
-        if: always()
-        shell: bash
-        run: |
-          {
-            echo "### EC2 deployment"
-            echo "- Service: \`$SERVICE\`"
-            echo "- Release: \`$RELEASE_ID\`"
-            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
-            echo "- SSM command: \`${{ steps.deploy.outputs.command_id }}\`"
-          } >> "$GITHUB_STEP_SUMMARY"
+    uses: ./.github/workflows/deploy-service-ec2.yml
+    with:
+      service: lanting-backend
+      ecr_repository: lanting-backend
+      release_id: ${{ github.sha }}
+      smoke_url: https://migration-lanting-api.id.life/healthz

--- a/.github/workflows/node-deploy-staging.yml
+++ b/.github/workflows/node-deploy-staging.yml
@@ -9,5 +9,5 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - run: docker build --platform linux/amd64 .

--- a/.github/workflows/rollback-ec2.yml
+++ b/.github/workflows/rollback-ec2.yml
@@ -1,0 +1,21 @@
+name: Roll back lanting-backend on EC2
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_release_id:
+        description: Exact previous-good release shown by idctl status
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  rollback:
+    uses: ./.github/workflows/rollback-service-ec2.yml
+    with:
+      service: lanting-backend
+      expected_release_id: ${{ inputs.expected_release_id }}
+      smoke_url: https://migration-lanting-api.id.life/healthz

--- a/.github/workflows/rollback-service-ec2.yml
+++ b/.github/workflows/rollback-service-ec2.yml
@@ -1,0 +1,207 @@
+name: Roll back service on EC2
+
+on:
+  workflow_call:
+    inputs:
+      service:
+        description: Catalog service id
+        required: true
+        type: string
+      expected_release_id:
+        description: Exact previous-good release currently expected on the host
+        required: true
+        type: string
+      aws_role_arn:
+        description: Optional repository-scoped GitHub OIDC role override
+        required: false
+        default: ''
+        type: string
+      smoke_url:
+        description: Optional public HTTPS health/readiness URL checked after rollback
+        required: false
+        default: ''
+        type: string
+      smoke_expected_status:
+        description: Exact HTTP status required from smoke_url
+        required: false
+        default: 200
+        type: number
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: production-${{ inputs.service }}
+  cancel-in-progress: false
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: production
+    env:
+      AWS_REGION: ap-southeast-1
+      SERVICE: ${{ inputs.service }}
+      EXPECTED_RELEASE_ID: ${{ inputs.expected_release_id }}
+      SMOKE_URL: ${{ inputs.smoke_url }}
+      SMOKE_EXPECTED_STATUS: ${{ inputs.smoke_expected_status }}
+    steps:
+      - name: Validate rollback inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$SERVICE" =~ ^[a-z0-9][a-z0-9-]+$ ]]
+          [[ "$EXPECTED_RELEASE_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]
+          if [[ -n "$SMOKE_URL" && ! "$SMOKE_URL" =~ ^https://[A-Za-z0-9.-]+(/[^[:space:]]*)?$ ]]; then
+            echo "smoke_url must be an HTTPS URL without credentials or a custom port" >&2
+            exit 2
+          fi
+          [[ "$SMOKE_EXPECTED_STATUS" =~ ^[1-5][0-9]{2}$ ]]
+
+      - name: Select repository-scoped AWS role
+        id: aws-role
+        shell: bash
+        env:
+          EXPLICIT_ROLE_ARN: ${{ inputs.aws_role_arn }}
+        run: |
+          set -euo pipefail
+          expected_role_arn="arn:aws:iam::550939689070:role/id-life-github-deploy-$SERVICE"
+          role_arn="${EXPLICIT_ROLE_ARN:-$expected_role_arn}"
+          [[ "$role_arn" == "$expected_role_arn" ]]
+          echo "role_arn=$role_arn" >> "$GITHUB_OUTPUT"
+
+      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+        with:
+          role-to-assume: ${{ steps.aws-role.outputs.role_arn }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Roll back through service-scoped SSM document
+        id: rollback
+        shell: bash
+        run: |
+          set -euo pipefail
+          document="id-life-rollback-$SERVICE"
+
+          managed_instances="$(aws ssm describe-instance-information \
+            --filters 'Key=tag:Project,Values=id-life' \
+            --output json)"
+          mapfile -t online_instance_ids < <(jq -r \
+            '.InstanceInformationList[] | select(.PingStatus == "Online") | .InstanceId' \
+            <<<"$managed_instances")
+          instance_ids=()
+          if (( ${#online_instance_ids[@]} > 0 )); then
+            exact_instances="$(aws ec2 describe-instances \
+              --instance-ids "${online_instance_ids[@]}" \
+              --filters \
+                'Name=tag:Project,Values=id-life' \
+                'Name=tag:Environment,Values=production' \
+                'Name=instance-state-name,Values=running' \
+              --output json)"
+            mapfile -t instance_ids < <(jq -r \
+              '.Reservations[].Instances[].InstanceId' <<<"$exact_instances")
+          fi
+          if (( ${#instance_ids[@]} != 1 )); then
+            echo "::error title=Unsafe runtime target set::expected exactly one online production runtime host, found ${#instance_ids[@]}"
+            exit 1
+          fi
+          instance_id="${instance_ids[0]}"
+          [[ "$instance_id" =~ ^i-[a-f0-9]+$ ]]
+
+          jq -n --arg release "$EXPECTED_RELEASE_ID" \
+            '{expectedReleaseId:[$release]}' > parameters.json
+          command_id="$(aws ssm send-command \
+            --document-name "$document" \
+            --instance-ids "$instance_id" \
+            --parameters file://parameters.json \
+            --max-concurrency 1 \
+            --max-errors 0 \
+            --query 'Command.CommandId' \
+            --output text)"
+          echo "command_id=$command_id" >> "$GITHUB_OUTPUT"
+
+          report_invocation_failure() {
+            local invocation_id="$1" result safe_output
+            result="$(aws ssm get-command-invocation \
+              --command-id "$command_id" \
+              --instance-id "$invocation_id" \
+              --output json)"
+            jq -r '"::error title=SSM rollback failed::instance=\(.InstanceId) status=\(.Status) detail=\(.StatusDetails // "unknown") response=\(.ResponseCode // -1)"' <<<"$result"
+            safe_output="$(jq -r '[.StandardErrorContent, .StandardOutputContent] | map(select(type == "string" and length > 0)) | join("\n") | .[0:4096]' <<<"$result" \
+              | sed -E \
+                  -e 's/(AKIA|ASIA)[A-Z0-9]{16}/[REDACTED_AWS_ACCESS_KEY]/g' \
+                  -e 's/([Pp]assword|[Ss]ecret|[Tt]oken|[Aa]uthorization)(["'"'"'=: ]+)[^ ,;]+/\1\2[REDACTED]/g')"
+            if [[ -n "$safe_output" ]]; then
+              echo "::group::Sanitized SSM rollback diagnostic for $invocation_id"
+              while IFS= read -r line; do printf '| %s\n' "$line"; done <<<"$safe_output"
+              echo "::endgroup::"
+            fi
+          }
+
+          completed=false
+          for attempt in $(seq 1 360); do
+            invocations="$(aws ssm list-command-invocations \
+              --command-id "$command_id" \
+              --details \
+              --output json)"
+            invocation_count="$(jq '.CommandInvocations | length' <<<"$invocations")"
+            if (( invocation_count > 1 )); then
+              echo "::error title=Unsafe SSM fan-out::command unexpectedly has $invocation_count invocations"
+              while IFS= read -r failed_instance; do report_invocation_failure "$failed_instance"; done \
+                < <(jq -r '.CommandInvocations[].InstanceId' <<<"$invocations")
+              exit 1
+            fi
+            if (( invocation_count == 1 )); then
+              status="$(jq -r '.CommandInvocations[0].Status' <<<"$invocations")"
+              case "$status" in
+                Success) completed=true; break ;;
+                Failed|TimedOut|Cancelled|Cancelling)
+                  report_invocation_failure "$instance_id"
+                  exit 1
+                  ;;
+              esac
+            fi
+            sleep 5
+          done
+          if [[ "$completed" != "true" ]]; then
+            echo "::error title=SSM rollback timed out::command did not complete within 30 minutes"
+            report_invocation_failure "$instance_id"
+            exit 1
+          fi
+
+      - name: Verify public ALB route
+        if: ${{ inputs.smoke_url != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual_status=""
+          for attempt in $(seq 1 12); do
+            actual_status="$(curl \
+              --proto '=https' \
+              --tlsv1.2 \
+              --silent \
+              --show-error \
+              --output /dev/null \
+              --write-out '%{http_code}' \
+              --connect-timeout 5 \
+              --max-time 15 \
+              "$SMOKE_URL" || true)"
+            [[ "$actual_status" == "$SMOKE_EXPECTED_STATUS" ]] && break
+            sleep 5
+          done
+          if [[ "$actual_status" != "$SMOKE_EXPECTED_STATUS" ]]; then
+            echo "::error title=Public smoke failed::expected HTTP $SMOKE_EXPECTED_STATUS, received ${actual_status:-network-error}"
+            exit 1
+          fi
+
+      - name: Record rollback summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### EC2 rollback"
+            echo "- Service: \`$SERVICE\`"
+            echo "- Expected previous-good release: \`$EXPECTED_RELEASE_ID\`"
+            echo "- SSM command: \`${{ steps.rollback.outputs.command_id }}\`"
+            if [[ -n "$SMOKE_URL" ]]; then echo "- Public smoke gate: HTTP $SMOKE_EXPECTED_STATUS passed"; fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- host the public-repository reusable deploy and rollback workflows locally
- use the exact per-service OIDC role and singleton SSM target
- pin third-party Actions by commit, add sanitized diagnostics and temporary-domain smoke checks
- keep deploy role inherited so test remains test and production remains production

## Safety
- no Route 53 or EKS changes
- application secrets remain host-only
- production scheduler activation is not requested

## Verification
- all workflow YAML parses successfully
- copied reusable workflow logic matches the tested aws-runtime implementation
- git diff --check passes