### PR TITLE
Harden bio EC2 deployment workflow

### DIFF
--- a/.github/workflows/node-deploy-bio-staging.yml
+++ b/.github/workflows/node-deploy-bio-staging.yml
@@ -12,5 +12,5 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - run: docker build --platform linux/amd64 .

--- a/.github/workflows/node-deploy-bio.yml
+++ b/.github/workflows/node-deploy-bio.yml
@@ -5,97 +5,15 @@ on:
     branches:
       - bio
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    environment: production
-    permissions:
-      contents: read
-      id-token: write
-    concurrency:
-      group: production-lanting-backend-bio
-      cancel-in-progress: false
-    env:
-      AWS_REGION: ap-southeast-1
-      SERVICE: lanting-backend-bio
-      ECR_REPOSITORY: lanting-backend
-      RELEASE_ID: ${{ github.sha }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Validate immutable deployment inputs
-        shell: bash
-        run: |
-          set -euo pipefail
-          [[ "$SERVICE" == "lanting-backend-bio" ]]
-          [[ "$ECR_REPOSITORY" == "lanting-backend" ]]
-          [[ "$RELEASE_ID" =~ ^[a-f0-9]{40}$ ]]
-          [[ "$RELEASE_ID" == "$GITHUB_SHA" ]]
-      - uses: aws-actions/configure-aws-credentials@v5
-        with:
-          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN || 'arn:aws:iam::550939689070:role/id-life-github-runtime-deploy' }}
-          aws-region: ${{ env.AWS_REGION }}
-      - id: ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - uses: docker/setup-buildx-action@v3
-      - name: Build and push amd64 image
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64
-          push: true
-          provenance: mode=max
-          sbom: true
-          tags: ${{ steps.ecr.outputs.registry }}/lanting-backend:${{ github.sha }}
-      - name: Deploy immutable digest through service-scoped SSM document
-        id: deploy
-        shell: bash
-        env:
-          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
-          REGISTRY: ${{ steps.ecr.outputs.registry }}
-        run: |
-          set -euo pipefail
-          [[ "$IMAGE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]
-          image="$REGISTRY/$ECR_REPOSITORY@$IMAGE_DIGEST"
-          document="id-life-deploy-$SERVICE"
-          jq -n --arg image "$image" --arg release "$RELEASE_ID" \
-            '{image:[$image],releaseId:[$release],deployRole:["test"],schedulerBatonConfirmed:["false"]}' > parameters.json
-          command_id="$(aws ssm send-command \
-            --document-name "$document" \
-            --targets 'Key=tag:Project,Values=id-life' 'Key=tag:Environment,Values=production' \
-            --parameters file://parameters.json \
-            --max-concurrency 1 \
-            --max-errors 0 \
-            --query 'Command.CommandId' \
-            --output text)"
-          echo "command_id=$command_id" >> "$GITHUB_OUTPUT"
-          instance_id=""
-          for attempt in $(seq 1 60); do
-            instance_id="$(aws ssm list-command-invocations --command-id "$command_id" --query 'CommandInvocations[0].InstanceId' --output text)"
-            [[ "$instance_id" =~ ^i-[a-f0-9]+$ ]] && break
-            sleep 2
-          done
-          [[ "$instance_id" =~ ^i-[a-f0-9]+$ ]]
-          status="Pending"
-          for attempt in $(seq 1 180); do
-            status="$(aws ssm get-command-invocation --command-id "$command_id" --instance-id "$instance_id" --query Status --output text)"
-            case "$status" in
-              Success) break ;;
-              Failed|TimedOut|Cancelled|Cancelling) exit 1 ;;
-            esac
-            sleep 5
-          done
-          [[ "$status" == "Success" ]]
-      - name: Record deployment summary
-        if: always()
-        shell: bash
-        run: |
-          {
-            echo "### EC2 deployment"
-            echo "- Service: \`$SERVICE\`"
-            echo "- Release: \`$RELEASE_ID\`"
-            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
-            echo "- SSM command: \`${{ steps.deploy.outputs.command_id }}\`"
-          } >> "$GITHUB_STEP_SUMMARY"
+    uses: id-life/lanting-backend/.github/workflows/deploy-service-ec2.yml@d279d25e3db178427f0ba0f80f7318863f5e5cb6
+    with:
+      service: lanting-backend-bio
+      ecr_repository: lanting-backend
+      release_id: ${{ github.sha }}
+      smoke_url: https://migration-lanting-bio-api.id.life/healthz

--- a/.github/workflows/rollback-ec2.yml
+++ b/.github/workflows/rollback-ec2.yml
@@ -1,0 +1,21 @@
+name: Roll back lanting-backend-bio on EC2
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_release_id:
+        description: Exact previous-good release shown by idctl status
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  rollback:
+    uses: id-life/lanting-backend/.github/workflows/rollback-service-ec2.yml@d279d25e3db178427f0ba0f80f7318863f5e5cb6
+    with:
+      service: lanting-backend-bio
+      expected_release_id: ${{ inputs.expected_release_id }}
+      smoke_url: https://migration-lanting-bio-api.id.life/healthz


### PR DESCRIPTION
## Summary
- replace the legacy inline shared-role deployment with the reviewed public reusable workflow pinned to merge commit d279d25
- use the exact lanting-backend-bio OIDC role, singleton SSM target and inherited deploy role
- add temporary-domain smoke validation and guarded manual rollback
- pin the dev-bio checkout Action

## Safety
- no Route 53 or EKS changes
- production scheduler activation is not requested
- application secrets remain host-only

## Verification
- referenced deploy and rollback reusable workflow files exist at the pinned immutable commit
- all changed workflow YAML parses successfully
- git diff --check passes