### PR TITLE
Pull current base images in EC2 deploys

### DIFF
--- a/.github/workflows/deploy-service-ec2.yml
+++ b/.github/workflows/deploy-service-ec2.yml
@@ -124,6 +124,7 @@ jobs:
           context: ${{ inputs.docker_context }}
           file: ${{ inputs.dockerfile }}
           platforms: linux/amd64
+          pull: true
           push: true
           provenance: mode=max
           sbom: true


### PR DESCRIPTION
## What changed

- force the public Lanting EC2 reusable workflow to pull the current Dockerfile base image before each amd64 build

## Why

ECR BASIC scanning showed that a successful cached build can retain stale Debian security packages. This keeps the public-repository workflow aligned with the central runtime workflow without changing its OIDC, digest, SSM, smoke, or scheduler controls.

## Impact

Merging to `main` rebuilds only `lanting-backend` through the existing test-role blue/green deployment. Production DNS and EKS are unchanged. The `bio` caller remains pinned until this main commit is proven successful, then receives a separate immutable-ref update.

## Validation

- all workflow YAML parses successfully
- `git diff --check`
- one-line parity review against `id-life/aws-runtime` PR #15
