### PR TITLE
ci: refresh base images for bio deploys

### DIFF
--- a/.github/workflows/node-deploy-bio.yml
+++ b/.github/workflows/node-deploy-bio.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   deploy:
-    uses: id-life/lanting-backend/.github/workflows/deploy-service-ec2.yml@d279d25e3db178427f0ba0f80f7318863f5e5cb6
+    uses: id-life/lanting-backend/.github/workflows/deploy-service-ec2.yml@aa4b776abf76c80f74aa09823518f151c8a4b4a9
     with:
       service: lanting-backend-bio
       ecr_repository: lanting-backend


### PR DESCRIPTION
## Summary
- pin the bio caller to the reviewed reusable workflow from main
- ensure future bio builds pull the current base image before building

## Validation
- YAML parsed successfully
- git diff --check passed

This only updates the migration deployment workflow; it does not modify Route 53 or EKS.