### PR TITLE
Add production config redeploy button

### DIFF
--- a/.github/workflows/redeploy-config-bio.yml
+++ b/.github/workflows/redeploy-config-bio.yml
@@ -1,0 +1,20 @@
+name: Redeploy bio production configuration
+
+on:
+  workflow_dispatch:
+    inputs:
+      change_reference:
+        description: Auditable config or incident reference; never enter a Secret value
+        required: true
+        type: string
+
+jobs:
+  redeploy:
+    permissions:
+      contents: read
+      id-token: write
+    uses: id-life/aws-runtime/.github/workflows/redeploy-config.yml@main
+    with:
+      service: lanting-backend-bio
+      change_reference: ${{ inputs.change_reference }}
+      smoke_url: https://lanting-bio-api.id.life/healthz

--- a/.github/workflows/redeploy-config-main.yml
+++ b/.github/workflows/redeploy-config-main.yml
@@ -1,0 +1,20 @@
+name: Redeploy main production configuration
+
+on:
+  workflow_dispatch:
+    inputs:
+      change_reference:
+        description: Auditable config or incident reference; never enter a Secret value
+        required: true
+        type: string
+
+jobs:
+  redeploy:
+    permissions:
+      contents: read
+      id-token: write
+    uses: id-life/aws-runtime/.github/workflows/redeploy-config.yml@main
+    with:
+      service: lanting-backend
+      change_reference: ${{ inputs.change_reference }}
+      smoke_url: https://lanting-api.id.life/healthz


### PR DESCRIPTION
Adds a thin manual GitHub Action that reuses the current immutable release and invokes the central repository-scoped configuration redeploy workflow. It never reads or accepts application Secret values.